### PR TITLE
Update introduction.md

### DIFF
--- a/automatic-login/credential-management-api/introduction.md
+++ b/automatic-login/credential-management-api/introduction.md
@@ -209,7 +209,7 @@ options 包含以下字段：
     - `providers`:
         `{Array}` 联合登录账号供应者 id 组成的数组
 - `unmediated`:
-    `{boolean}` 是否跳过账号选择器自动登录
+    `{boolean}` 是否显示账号选择器
 
 ### 获取账号密码登录凭证
 


### PR DESCRIPTION
unmediated=true 的实际含义是是否显示帐号选择器，不是自动登录，这样写有点误导
另外，demo 里又不严谨的地方，navigator.credentials.get 是不能显式拿到密码的，密码只能作为PasswordCredential对象中的一部分，对外是不可访问的，查了一些资料，有说 get 返回的 cred 在 chrome >= 60的版本会有 cred.password，目前 mac/android 都不到60，windows 没实测，ios 没有这个 API，cred.password 多数情况下都是返回的 undefined，但是 demo 直接就赋值用了，最好判断一下加以区分。demo 因为是 mock 的登录，所以看起来没什么异常